### PR TITLE
Return 204 in test to match API

### DIFF
--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -44,7 +44,7 @@ class TestApp < Sinatra::Base
 
   post '/good' do
     self.class.last_request = request
-    [201, 'Accepted']
+    [204, '']
   end
 
   post '/bad' do


### PR DESCRIPTION
The main code already uses `Net::HTTPSuccess` which accepts any `2xx` response code, but this updates the test to return a code matching the public API.