### PR TITLE
Hard code version

### DIFF
--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -17,9 +17,9 @@
 require 'logstash/namespace'
 require 'logstash/outputs/base'
 require 'logstash/json'
-require_relative '../../../version'
 
 MAX_RETRIES = 5
+VERSION = '0.2.1'
 
 module LogStash
   module Outputs
@@ -28,8 +28,6 @@ module LogStash
 
     # An output which sends logs to the Dynatrace log ingest v2 endpoint formatted as JSON
     class Dynatrace < LogStash::Outputs::Base
-      @plugin_version = ::DynatraceConstants::VERSION
-
       config_name 'dynatrace'
 
       # The full URL of the Dynatrace log ingestion endpoint:
@@ -63,7 +61,7 @@ module LogStash
 
       def headers
         {
-          'User-Agent' => "logstash-output-dynatrace v#{@plugin_version}",
+          'User-Agent' => "logstash-output-dynatrace v#{VERSION}",
           'Content-Type' => 'application/json; charset=utf-8',
           'Authorization' => "Api-Token #{@api_key}"
         }

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -19,7 +19,7 @@ require 'logstash/outputs/base'
 require 'logstash/json'
 
 MAX_RETRIES = 5
-VERSION = '0.2.1'
+PLUGIN_VERSION = '0.2.1'
 
 module LogStash
   module Outputs
@@ -61,7 +61,7 @@ module LogStash
 
       def headers
         {
-          'User-Agent' => "logstash-output-dynatrace v#{VERSION}",
+          'User-Agent' => "logstash-output-dynatrace v#{PLUGIN_VERSION}",
           'Content-Type' => 'application/json; charset=utf-8',
           'Authorization' => "Api-Token #{@api_key}"
         }

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require_relative '../spec_helper'
+require_relative '../../version'
 require 'logstash/codecs/plain'
 require 'logstash/event'
 require 'sinatra'
@@ -35,7 +36,6 @@ describe LogStash::Outputs::Dynatrace do
 
   before do
     subject.register
-    subject.plugin_version = "1.2.3"
   end
 
   it 'does not send empty events' do
@@ -79,7 +79,7 @@ describe LogStash::Outputs::Dynatrace do
 
     it 'includes user agent' do
       allow(subject).to receive(:send) do |req|
-        expect(req['User-Agent']).to eql('logstash-output-dynatrace v1.2.3')
+        expect(req['User-Agent']).to eql("logstash-output-dynatrace v#{::DynatraceConstants::VERSION}")
         Net::HTTPOK.new "1.1", "200", "OK"
       end
       subject.multi_receive(events)

--- a/version.rb
+++ b/version.rb
@@ -15,5 +15,6 @@
 # limitations under the License.
 
 module DynatraceConstants
+  # Also required to change the version in lib/logstash/outputs/dynatrace.rb
   VERSION = '0.2.1'
 end


### PR DESCRIPTION
I admit defeat. Loading the version from a version file seems impossible for some reason in logstash. What works locally fails in the actual logstash installation.

Hard coding the version into the UA header. If the version is updated but the header is not, the tests will fail and we will catch it.