### PR TITLE
Use user agent version format

### DIFF
--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -19,7 +19,7 @@ require 'logstash/outputs/base'
 require 'logstash/json'
 
 MAX_RETRIES = 5
-PLUGIN_VERSION = '0.2.1'
+PLUGIN_VERSION = '0.2.2'
 
 module LogStash
   module Outputs

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -61,7 +61,7 @@ module LogStash
 
       def headers
         {
-          'User-Agent' => "logstash-output-dynatrace v#{PLUGIN_VERSION}",
+          'User-Agent' => "logstash-output-dynatrace/#{PLUGIN_VERSION}",
           'Content-Type' => 'application/json; charset=utf-8',
           'Authorization' => "Api-Token #{@api_key}"
         }

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -79,7 +79,7 @@ describe LogStash::Outputs::Dynatrace do
 
     it 'includes user agent' do
       allow(subject).to receive(:send) do |req|
-        expect(req['User-Agent']).to eql("logstash-output-dynatrace v#{::DynatraceConstants::VERSION}")
+        expect(req['User-Agent']).to eql("logstash-output-dynatrace/#{::DynatraceConstants::VERSION}")
         Net::HTTPOK.new "1.1", "200", "OK"
       end
       subject.multi_receive(events)

--- a/version.rb
+++ b/version.rb
@@ -16,5 +16,5 @@
 
 module DynatraceConstants
   # Also required to change the version in lib/logstash/outputs/dynatrace.rb
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end


### PR DESCRIPTION
Update user agent version format to follow [RFC 7231, 5.5.3](https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3).