### PR TITLE
log and re-raise unknown errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.1
+ - Log and re-raise unknown errors
+
 ## 0.3.0
  - Log response bodies on client errors
 

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -19,7 +19,7 @@ require 'logstash/outputs/base'
 require 'logstash/json'
 
 MAX_RETRIES = 5
-PLUGIN_VERSION = '0.3.0'
+PLUGIN_VERSION = '0.3.1'
 
 module LogStash
   module Outputs
@@ -105,6 +105,9 @@ module LogStash
             @logger.error("Failed to export logs to Dynatrace.")
             return
           end
+        rescue StandardError => e
+          @logger.error("Unknown error raised", :error => e.inspect)
+          raise e
         end
       end
 

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -135,4 +135,17 @@ describe LogStash::Outputs::Dynatrace do
       subject.multi_receive(events)
     end
   end
+
+  context 'when an unknown error occurs' do
+    it 'logs and re-raises the error' do
+      class BadEvents
+        def length
+          1
+        end
+      end
+
+      expect(subject.logger).to receive(:error)
+      expect { subject.multi_receive(BadEvents.new) }.to raise_error(StandardError)
+    end
+  end
 end

--- a/version.rb
+++ b/version.rb
@@ -16,5 +16,5 @@
 
 module DynatraceConstants
   # Also required to change the version in lib/logstash/outputs/dynatrace.rb
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
This just adds an error log in the case that the plugin throws an error that is not otherwise caught. This should help us to be absolutely sure if an error was caused by our plugin or somewhere else.