### PR TITLE
Use password type for api_key configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.3.1
  - Log and re-raise unknown errors
+ - Use [password](https://www.elastic.co/guide/en/logstash/current/configuration-file-structure.html#password) type for `api_key` configuration
 
 ## 0.3.0
  - Log response bodies on client errors

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -36,7 +36,7 @@ module LogStash
       config :ingest_endpoint_url, validate: :uri, required: true
 
       # The API token to use to authenticate requests to the log ingestion endpoint. Must have `logs.ingest` (Ingest Logs) scope.
-      config :api_key, validate: :string, required: true
+      config :api_key, validate: :password, required: true
 
       # Disable SSL validation by setting :verify_mode OpenSSL::SSL::VERIFY_NONE
       config :ssl_verify_none, validate: :boolean, default: false
@@ -63,7 +63,7 @@ module LogStash
         {
           'User-Agent' => "logstash-output-dynatrace/#{PLUGIN_VERSION}",
           'Content-Type' => 'application/json; charset=utf-8',
-          'Authorization' => "Api-Token #{@api_key}"
+          'Authorization' => "Api-Token #{@api_key.value}"
         }
       end
 


### PR DESCRIPTION
This should be a non-breaking change as existing configs should work identically