### PR TITLE
Add Net::OpenTimeout to the list of retried exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
+## 0.3.2
+
+- Add Net::OpenTimeout to the list of retried exceptions
+
 ## 0.3.1
- - Log and re-raise unknown errors
- - Use [password](https://www.elastic.co/guide/en/logstash/current/configuration-file-structure.html#password) type for `api_key` configuration
+
+- Log and re-raise unknown errors
+- Use [password](https://www.elastic.co/guide/en/logstash/current/configuration-file-structure.html#password) type for `api_key` configuration
 
 ## 0.3.0
- - Log response bodies on client errors
+
+- Log response bodies on client errors
 
 ## 0.2.0
- - Add retries with exponential backoff (#8)
+
+- Add retries with exponential backoff (#8)
 
 ## 0.1.0
- - Initial release
+
+- Initial release

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -93,8 +93,9 @@ module LogStash
 
           raise RetryableError.new "code #{response.code}" if retryable(response)
 
-        rescue Net::HTTPBadResponse, RetryableError => e
-          # indicates a protocol error
+        rescue Net::OpenTimeout, Net::HTTPBadResponse, RetryableError => e
+          # Net::OpenTimeout indicates a connection could not be established within the timeout period
+          # Net::HTTPBadResponse indicates a protocol error
           if retries < MAX_RETRIES
             sleep_seconds = 2 ** retries
             @logger.warn("Failed to contact dynatrace: #{e.message}. Trying again after #{sleep_seconds} seconds.")

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -19,7 +19,7 @@ require 'logstash/outputs/base'
 require 'logstash/json'
 
 MAX_RETRIES = 5
-PLUGIN_VERSION = '0.3.1'
+PLUGIN_VERSION = '0.3.2'
 
 module LogStash
   module Outputs

--- a/version.rb
+++ b/version.rb
@@ -16,5 +16,5 @@
 
 module DynatraceConstants
   # Also required to change the version in lib/logstash/outputs/dynatrace.rb
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
Fixes #20

Net::OpenTimeout is a subclass of Timeout::Error that occurs when the TCP open fails. This can happen in the event of an intermittent network failure or a misconfiguration. Adding it to the list of retryable errors minimizes the risk that an intermittent network failure causes data loss.