### PR TITLE
Split large batches

### DIFF
--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -116,8 +116,8 @@ module LogStash
         def offer(event)
           serialized_event = LogStash::Json.dump(event.to_hash)
           # 2 square brackets, the length of all previously serialized strings, commas, and the current event size
-          batch_size = 2 + @batch_events_size + @serialized_events.length + serialized_event.length
-          return false if batch_size > @max_batch_size
+          batch_size_bytes = 2 + @batch_events_size + @serialized_events.length + serialized_event.length
+          return false if batch_size_bytes > @max_batch_size
 
           @serialized_events.push(serialized_event)
           @batch_events_size += serialized_event.length

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -324,11 +324,6 @@ module LogStash
       def log_failure(message, opts)
         @logger.error(message, opts)
       end
-
-      # # Format the HTTP body
-      # def event_body(event)
-      #   "#{LogStash::Json.dump(event.map(&:to_hash)).chomp}\n"
-      # end
     end
   end
 end

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -176,7 +176,9 @@ module LogStash
         events.each do |event|
           if not batcher.offer(event)
             pending << [batcher.drain(), 0]
-            batcher.offer(event)
+            if not batcher.offer(event)
+              @logger.warn("Event larger than max_payload_size dropped", size: LogStash::Json.dump(event.to_hash).length )
+            end
           end
         end
 

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -132,7 +132,7 @@ describe LogStash::Outputs::Dynatrace do
     end
   end
 
-  context 'performing a get' do
+  context 'performing a request' do
     describe 'invoking the request' do
       before do
         subject.multi_receive([event])
@@ -184,6 +184,17 @@ describe LogStash::Outputs::Dynatrace do
 
       it 'should make three total requests' do
         expect(subject).to have_received(:send_event).exactly(3).times
+      end
+    end
+
+    context 'with more than 4.5MB of events' do
+      before do
+        allow(subject).to receive(:send_event) {|e, att| [:success, e, att] }
+        subject.multi_receive([*1..2].map{|n| LogStash::Event.new({ 'n' => n.to_s * 2_500_001 })})
+      end
+
+      it 'should split the chunk into multiple requests' do
+        expect(subject).to have_received(:send_event).exactly(2).times
       end
     end
   end

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -190,7 +190,7 @@ describe LogStash::Outputs::Dynatrace do
     context 'with more than 4.5MB of events' do
       before do
         allow(subject).to receive(:send_event) { |e, att| [:success, e, att] }
-        subject.multi_receive([*1..2].map { |n| LogStash::Event.new({ 'n' => n.to_s * 2_500_001 }) })
+        subject.multi_receive([1,2].map { |n| LogStash::Event.new({ 'n' => n.to_s * 2_500_001 }) })
       end
 
       it 'should split the chunk into multiple requests' do

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -189,8 +189,8 @@ describe LogStash::Outputs::Dynatrace do
 
     context 'with more than 4.5MB of events' do
       before do
-        allow(subject).to receive(:send_event) {|e, att| [:success, e, att] }
-        subject.multi_receive([*1..2].map{|n| LogStash::Event.new({ 'n' => n.to_s * 2_500_001 })})
+        allow(subject).to receive(:send_event) { |e, att| [:success, e, att] }
+        subject.multi_receive([*1..2].map { |n| LogStash::Event.new({ 'n' => n.to_s * 2_500_001 }) })
       end
 
       it 'should split the chunk into multiple requests' do

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -214,7 +214,7 @@ describe LogStash::Outputs::Dynatrace do
     context 'with one small event and one too large event' do
       before do
         allow(subject).to receive(:send_event) { |e, att| [:success, e, att] }
-        subject.multi_receive([LogStash::Event.new({ 'event' => 'small' },
+        subject.multi_receive([LogStash::Event.new({ 'event' => 'small' }),
                                LogStash::Event.new({ 'event' => 'n' * 4_500_001 })])
       end
 

--- a/version.yaml
+++ b/version.yaml
@@ -1,1 +1,1 @@
-logstash-output-dynatrace: '0.5.0'
+logstash-output-dynatrace: '0.5.1'


### PR DESCRIPTION
Fixes #30 

Splits batches of events larger than 4.5MB into multiple requests in order to stay under the 5MB API limit.

Introduces a `Batcher` component which builds batches and counts the size of the resulting request body. The `offer` method returns `true` if the event is accepted as a part of the current batch or `false` if the event would make the batch too large. `drain_and_serialize` returns a JSON string request body for export and clears the array.