### PR TITLE
Pin Travis CI status badge to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logstash Dynatrace output plugin
 
-[![Travis Build Status](https://app.travis-ci.com/dynatrace-oss/logstash-output-dynatrace.svg)](https://app.travis-ci.com/dynatrace-oss/logstash-output-dynatrace)
+[![Travis Build Status](https://api.travis-ci.com/dynatrace-oss/logstash-output-dynatrace.svg?branch=main)](https://app.travis-ci.com/dynatrace-oss/logstash-output-dynatrace)
 
 > This project is developed and maintained by Dynatrace R&D.
 


### PR DESCRIPTION
Otherwise it will show a "failing" status badge if any branch build is failing even when the `main` branch is passing.