### PR TITLE
JRuby 9.4.6.0 and logstash 8.x compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+- Add new development dependency `rackup` for logstash 8.x compatibility
+
 ## 0.6.0
 
 - Disable cookie processing by default

--- a/logstash-output-dynatrace.gemspec
+++ b/logstash-output-dynatrace.gemspec
@@ -52,4 +52,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rubocop', '1.9.1'
   s.add_development_dependency 'rubocop-rake', '0.5.1'
+
+  # Pin to avoid using new Fiber-based implementation that breaks tests here
+  s.add_development_dependency 'rackup', "< 2.1.0"
 end

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -347,7 +347,7 @@ describe LogStash::Outputs::Dynatrace do
       end
 
       let(:last_request) { TestApp.last_request }
-      let(:body) { last_request.body.read }
+      let(:body) { read_last_request_body(last_request) }
       let(:content_type) { last_request.env['CONTENT_TYPE'] }
 
       it 'should receive the request' do
@@ -483,7 +483,7 @@ RSpec.describe LogStash::Outputs::Dynatrace do # different block as we're starti
   after  { subject.close }
 
   let(:last_request) { TestApp.last_request }
-  let(:last_request_body) { last_request.body.read }
+  let(:last_request_body) { read_last_request_body(last_request) }
 
   let(:event) { LogStash::Event.new('message' => 'hello!') }
 
@@ -549,4 +549,11 @@ RSpec.describe LogStash::Outputs::Dynatrace do # different block as we're starti
       end
     end
   end
+end
+
+# Pre-emptively rewind the retrieval of `last_request.body` - for form based endpoints, the body
+# is placed in params, and body is empty, requiring a `rewind` for the body to be available for comparison
+def read_last_request_body(last_request)
+  last_request.body.rewind
+  last_request.body.read
 end

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -437,10 +437,10 @@ describe LogStash::Outputs::Dynatrace do
 end
 
 RSpec.describe LogStash::Outputs::Dynatrace do # different block as we're starting web server with TLS
-  @@default_server_settings = TestApp.server_settings.dup
+  let(:default_server_settings) { TestApp.server_settings.dup }
 
   before do
-    TestApp.server_settings = @@default_server_settings.merge(webrick_config)
+    TestApp.server_settings = default_server_settings.merge(webrick_config)
 
     TestApp.last_request = nil
 
@@ -465,7 +465,7 @@ RSpec.describe LogStash::Outputs::Dynatrace do # different block as we're starti
     rescue StandardError
       nil
     end
-    TestApp.server_settings = @@default_server_settings
+    TestApp.server_settings = default_server_settings
   end
 
   let(:ssl_cert_host) { 'localhost' }

--- a/version.yaml
+++ b/version.yaml
@@ -1,1 +1,1 @@
-logstash-output-dynatrace: '0.6.0'
+logstash-output-dynatrace: '0.6.1'


### PR DESCRIPTION
# Remove toplevel class variable

This is required for JRuby 9.4.6.0 compatibility

Ruby 3.0.0 changed this from a warning to a RuntimeError https://bugs.ruby-lang.org/issues/14541
https://ruby-doc.org/core-3.0.1/NEWS_md.html

This change was already made in the upstream plugin. https://github.com/logstash-plugins/logstash-output-http/pull/141

# Add rackup dependency

Adding this dev dependency is now needed as it is no longer included in the base logstash framework