### PR TITLE
Calculate batch sizes in bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+- Fix an error where max payload size was calculated using character count instead of bytes
+
 ## 0.7.0
 
 - Add new development dependency `rackup` for logstash 8.x compatibility

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -122,11 +122,11 @@ module LogStash
 
         def offer(serialized_event)
           # 2 square brackets, the length of all previously serialized strings, commas, and the current event size
-          batch_size_bytes = 2 + @batch_events_size + @serialized_events.length + serialized_event.length
+          batch_size_bytes = 2 + @batch_events_size + @serialized_events.length + serialized_event.bytesize
           return false if batch_size_bytes > @max_batch_size
 
           @serialized_events.push(serialized_event)
-          @batch_events_size += serialized_event.length
+          @batch_events_size += serialized_event.bytesize
           true
         end
 
@@ -178,8 +178,8 @@ module LogStash
 
         events.each do |event|
           serialized_event = LogStash::Json.dump(event.to_hash)
-          if serialized_event.length > @max_payload_size
-            log_params = { size: serialized_event.length }
+          if serialized_event.bytesize > @max_payload_size
+            log_params = { size: serialized_event.bytesize }
             log_params[:body] = serialized_event if @debug_include_body
             log_warning('Event larger than max_payload_size dropped', log_params)
             next

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -244,14 +244,14 @@ describe LogStash::Outputs::Dynatrace do
     it 'should send 2 400B messages in multiple requests' do
       subject.multi_receive([1, 2].map { |n| LogStash::Event.new({ 'n' => n.to_s * 400 }) })
       expect(subject).to have_received(:send_event).exactly(2).times do |s|
-        expect(s.length).to be <= max_payload_size
+        expect(s.bytesize).to be <= max_payload_size
       end
     end
 
     it 'should send 2 100B messages in a single request' do
       subject.multi_receive([1, 2].map { |n| LogStash::Event.new({ 'n' => n.to_s * 100 }) })
       expect(subject).to have_received(:send_event).exactly(1).times do |s|
-        expect(s.length).to be <= max_payload_size
+        expect(s.bytesize).to be <= max_payload_size
       end
     end
 
@@ -262,7 +262,7 @@ describe LogStash::Outputs::Dynatrace do
         LogStash::Event.new({ 'event' => 'n' * 400 }),
       ])
       expect(subject).to have_received(:send_event).exactly(1).times do |s|
-        expect(s.length).to be <= max_payload_size
+        expect(s.bytesize).to be <= max_payload_size
       end
     end
   end

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -233,7 +233,8 @@ describe LogStash::Outputs::Dynatrace do
   end
 
   context 'max_payload_size 500' do
-    let(:config) { { 'ingest_endpoint_url' => ingest_endpoint_url, 'api_key' => api_key, 'max_payload_size' => 500 } }
+    let(:max_payload_size) { 500 }
+    let(:config) { { 'ingest_endpoint_url' => ingest_endpoint_url, 'api_key' => api_key, 'max_payload_size' => max_payload_size } }
     subject { LogStash::Outputs::Dynatrace.new(config) }
 
     before do
@@ -242,12 +243,16 @@ describe LogStash::Outputs::Dynatrace do
 
     it 'should send 2 400B messages in multiple requests' do
       subject.multi_receive([1, 2].map { |n| LogStash::Event.new({ 'n' => n.to_s * 400 }) })
-      expect(subject).to have_received(:send_event).exactly(2).times
+      expect(subject).to have_received(:send_event).exactly(2).times do |s|
+        expect(s.length).to be <= max_payload_size
+      end
     end
 
     it 'should send 2 100B messages in a single request' do
       subject.multi_receive([1, 2].map { |n| LogStash::Event.new({ 'n' => n.to_s * 100 }) })
-      expect(subject).to have_received(:send_event).exactly(1).time
+      expect(subject).to have_received(:send_event).exactly(1).time do |s|
+        expect(s.length).to be <= max_payload_size
+      end
     end
 
     it 'should drop messages larger than max_payload_size' do
@@ -256,14 +261,9 @@ describe LogStash::Outputs::Dynatrace do
         LogStash::Event.new({ 'event' => 'n' * 600 }),
         LogStash::Event.new({ 'event' => 'n' * 400 }),
       ])
-      expect(subject).to have_received(:send_event).exactly(1).time
-    end
-
-    it 'should drop messages larger than max_payload_size' do
-      subject.multi_receive([
-        LogStash::Event.new({ 'event' => 'small' }),
-      ])
-      expect(subject).to have_received(:send_event).exactly(1).time
+      expect(subject).to have_received(:send_event).exactly(1).time do |s|
+        expect(s.length).to be <= max_payload_size
+      end
     end
   end
 

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -250,7 +250,7 @@ describe LogStash::Outputs::Dynatrace do
 
     it 'should send 2 100B messages in a single request' do
       subject.multi_receive([1, 2].map { |n| LogStash::Event.new({ 'n' => n.to_s * 100 }) })
-      expect(subject).to have_received(:send_event).exactly(1).time do |s|
+      expect(subject).to have_received(:send_event).exactly(1).times do |s|
         expect(s.length).to be <= max_payload_size
       end
     end
@@ -261,7 +261,7 @@ describe LogStash::Outputs::Dynatrace do
         LogStash::Event.new({ 'event' => 'n' * 600 }),
         LogStash::Event.new({ 'event' => 'n' * 400 }),
       ])
-      expect(subject).to have_received(:send_event).exactly(1).time do |s|
+      expect(subject).to have_received(:send_event).exactly(1).times do |s|
         expect(s.length).to be <= max_payload_size
       end
     end

--- a/version.yaml
+++ b/version.yaml
@@ -1,1 +1,1 @@
-logstash-output-dynatrace: '0.7.0'
+logstash-output-dynatrace: '0.7.1'


### PR DESCRIPTION
Fixes an issue where batches are incorrectly sized when the number of characters does not exactly match the number of bytes. This can happen when the payload contains unicode characters for example.