### PR TITLE
Log partial success warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.2
+
+- Log response bodies when the response is `200` indicating the request was only partially accepted
+ 
 ## 0.7.1
 
 - Fix an error where max payload size was calculated using character count instead of bytes

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -272,8 +272,7 @@ module LogStash
 
         if response_success?(response)
           # some events were not accepted but we don't know which ones or why
-          # log a warning
-          if response_partial_success?(response) log_partial_success_response(response)
+          log_partial_success_response(response) if response_partial_success?(response)
           [:success, event, attempt]
         elsif retryable_response?(response)
           log_retryable_response(response)

--- a/lib/logstash/outputs/dynatrace.rb
+++ b/lib/logstash/outputs/dynatrace.rb
@@ -161,7 +161,7 @@ module LogStash
       end
 
       def log_partial_success_response(response)
-        @logger.error("Encountered partial success response", code: response.code, body: response.body)
+        @logger.warn("Encountered partial success response", code: response.code, body: response.body)
       end
 
       def log_error_response(response, ingest_endpoint_url, event)

--- a/spec/outputs/dynatrace_spec.rb
+++ b/spec/outputs/dynatrace_spec.rb
@@ -168,6 +168,19 @@ describe LogStash::Outputs::Dynatrace do
       end
     end
 
+    context 'with partial success responses' do
+      let(:ingest_endpoint_url) { "http://localhost:#{port}/partial" }
+
+      before do
+        allow(subject).to receive(:log_partial_success_response)
+      end
+
+      it 'should warn on partial success' do
+        subject.multi_receive([event])
+        expect(subject).to have_received(:log_partial_success_response)
+      end
+    end
+
     context 'with retryable failing requests' do
       let(:ingest_endpoint_url) { "http://localhost:#{port}/retry" }
       let(:api_key) { 'placeholder-key' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,10 +95,15 @@ class TestApp < Sinatra::Base
   def self.retry_fail_count
     @retry_fail_count || 2
   end
-
+  
   multiroute(%w[get post put patch delete], '/good') do
     self.class.last_request = request
-    [200, 'YUP']
+    [204, 'YUP']
+  end
+
+  multiroute(%w[get post put patch delete], '/partial') do
+    self.class.last_request = request
+    [200, 'partial success']
   end
 
   multiroute(%w[get post put patch delete], '/bad') do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,7 +95,7 @@ class TestApp < Sinatra::Base
   def self.retry_fail_count
     @retry_fail_count || 2
   end
-  
+
   multiroute(%w[get post put patch delete], '/good') do
     self.class.last_request = request
     [204, 'YUP']

--- a/version.yaml
+++ b/version.yaml
@@ -1,1 +1,1 @@
-logstash-output-dynatrace: '0.7.1'
+logstash-output-dynatrace: '0.7.2'


### PR DESCRIPTION
While the expected `204` response indicates the log body was accepted, `200` responses indicate the request was only partially accepted. This adds logging to help diagnose why an event was dropped. https://docs.dynatrace.com/docs/discover-dynatrace/references/dynatrace-api/environment-api/log-monitoring-v2/post-ingest-logs#response-codes

<img width="945" alt="image" src="https://github.com/user-attachments/assets/c24ac031-f824-465c-86fd-dd49cf228c6d" />

```shell
$ curl -X POST -i https://<tenant>.live.dynatrace.com/api/v2/logs/ingest -H 'Authorization: Api-Token <token>' -H 'Content-Type: application/json' -d '[[{"content": "this log works just fine"}, {"content": "this is a log", "deep": {"nested": {"attribute": {"more": {"deeply": {"nested": { "not": "allowed" }}}}}} }]'
HTTP/1.1 200 OK
vary: Accept-Encoding
content-type: application/json;charset=utf-8
content-length: 99
[...]

{"success":{"code":200,"message":"Event(s) has attributes which are too nested for records: [1]."}}
```

This does _NOT_ add dropped events to any sort of retry queue because we do not know which events failed to send or why.